### PR TITLE
Fix intmax address

### DIFF
--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -37,6 +37,18 @@ func (pk *PublicKey) String() string {
 	return hex.EncodeToString(pk.Pk.Marshal())
 }
 
+// NewDummyPublicKey returns the point which the x coordinate is 1.
+//
+// NOTE: If the x coordinate is 0, there is no corresponding y value.
+func NewDummyPublicKey() *PublicKey {
+	const dummyPublicKeyY = 2
+	point := new(bn254.G1Affine)
+	point.X.SetOne()
+	point.Y.SetInt64(dummyPublicKeyY)
+
+	return &PublicKey{Pk: point}
+}
+
 // Add two public keys as elliptic curve points.
 func (pk *PublicKey) Add(a, b *PublicKey) *PublicKey {
 	if pk.Pk == nil {
@@ -257,7 +269,8 @@ func (a *PrivateKey) ToAddress() Address {
 }
 
 func NewAddressFromHex(s string) (Address, error) {
-	if len(s) != 66 || s[:2] != "0x" {
+	const int66Key = 66
+	if len(s) != int66Key || s[:2] != "0x" {
 		return Address{}, ErrAddressInvalid
 	}
 	b, err := hexutil.Decode(s)
@@ -269,7 +282,8 @@ func NewAddressFromHex(s string) (Address, error) {
 }
 
 func NewAddressFromBytes(b []byte) (Address, error) {
-	if len(b) != 32 {
+	const addressByteSize = 32
+	if len(b) != addressByteSize {
 		return Address{}, ErrAddressInvalid
 	}
 	var address Address
@@ -278,8 +292,9 @@ func NewAddressFromBytes(b []byte) (Address, error) {
 }
 
 func (a Address) Public() (*PublicKey, error) {
+	const mCompressedSmallest byte = 0b10 << 6
 	b := a.Bytes()
-	b[0] |= 0x80
+	b[0] |= mCompressedSmallest
 	point := new(bn254.G1Affine)
 	_, err := point.SetBytes(b)
 	if err != nil {

--- a/internal/accounts/accounts_test.go
+++ b/internal/accounts/accounts_test.go
@@ -98,3 +98,19 @@ func TestMarshalUnmarshal(t *testing.T) {
 
 	assert.True(t, publicKey.Equal(account.Public()))
 }
+
+func TestAddressToPublicKey(t *testing.T) {
+	t.Parallel()
+
+	account, err := intMaxAcc.NewPrivateKeyWithReCalcPubKeyIfPkNegates(big.NewInt(3))
+	assert.NoError(t, err)
+
+	accountAddress := account.ToAddress()
+	address := accountAddress.String()
+
+	publicKey := new(intMaxAcc.PublicKey)
+	err = publicKey.FromAddressString(address)
+	assert.NoError(t, err)
+
+	assert.True(t, account.PublicKey.Equal(publicKey))
+}

--- a/internal/accounts/accounts_test.go
+++ b/internal/accounts/accounts_test.go
@@ -108,8 +108,7 @@ func TestAddressToPublicKey(t *testing.T) {
 	accountAddress := account.ToAddress()
 	address := accountAddress.String()
 
-	publicKey := new(intMaxAcc.PublicKey)
-	err = publicKey.FromAddressString(address)
+	publicKey, err := intMaxAcc.NewPublicKeyFromAddressHex(address)
 	assert.NoError(t, err)
 
 	assert.True(t, account.PublicKey.Equal(publicKey))

--- a/internal/accounts/accounts_test.go
+++ b/internal/accounts/accounts_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestDummyPublicKey(t *testing.T) {
+	t.Parallel()
+
+	pk := intMaxAcc.NewDummyPublicKey()
+	assert.NotNil(t, pk)
+}
+
 func TestShouldNotGenerateNilAccount(t *testing.T) {
 	t.Parallel()
 

--- a/internal/accounts/errors.go
+++ b/internal/accounts/errors.go
@@ -27,3 +27,7 @@ var ErrPrivateKeyWithPublicKeyInvalid = errors.New(
 
 // ErrValidPublicKeyFail error: failed to valid public key.
 var ErrValidPublicKeyFail = errors.New("failed to valid public key")
+
+var ErrAddressInvalid = errors.New("invalid address")
+
+var ErrDecodeAddressFail = errors.New("failed to decode address")

--- a/internal/accounts/signature.go
+++ b/internal/accounts/signature.go
@@ -10,8 +10,6 @@ import (
 	"github.com/iden3/go-iden3-crypto/ffg"
 )
 
-const uint32ByteSize = 4
-
 // Calculate the signature of the message using the private key as follows:
 // messagePoint = hashToG2(message)
 // signature = privateKey * messagePoint
@@ -105,7 +103,10 @@ func hashToWeight(myPublicKey *fp.Element, hash []byte) *big.Int {
 	challenger := goldenposeidon.NewChallenger()
 	challenger.ObserveElements(flatten2)
 
-	const bn254OrderByteSize = 32
+	const (
+		bn254OrderByteSize = 32
+		uint32ByteSize     = 4
+	)
 	output := challenger.GetNChallenges(bn254OrderByteSize / uint32ByteSize)
 
 	a := goldenposeidon.FieldElementSliceToBigInt(output)

--- a/internal/accounts/signature.go
+++ b/internal/accounts/signature.go
@@ -10,6 +10,8 @@ import (
 	"github.com/iden3/go-iden3-crypto/ffg"
 )
 
+const uint32ByteSize = 4
+
 // Calculate the signature of the message using the private key as follows:
 // messagePoint = hashToG2(message)
 // signature = privateKey * messagePoint
@@ -103,10 +105,7 @@ func hashToWeight(myPublicKey *fp.Element, hash []byte) *big.Int {
 	challenger := goldenposeidon.NewChallenger()
 	challenger.ObserveElements(flatten2)
 
-	const (
-		bn254OrderByteSize = 32
-		uint32ByteSize     = 4
-	)
+	const bn254OrderByteSize = 32
 	output := challenger.GetNChallenges(bn254OrderByteSize / uint32ByteSize)
 
 	a := goldenposeidon.FieldElementSliceToBigInt(output)

--- a/internal/accounts/signature_test.go
+++ b/internal/accounts/signature_test.go
@@ -2,7 +2,6 @@ package accounts_test
 
 import (
 	"crypto/rand"
-	"encoding/binary"
 	"encoding/hex"
 	intMaxAcc "intmax2-node/internal/accounts"
 	"intmax2-node/internal/finite_field"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
-	"github.com/iden3/go-iden3-crypto/ffg"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -25,24 +23,28 @@ func TestSignatureByINTMAXAccount(t *testing.T) {
 	keyPair, err := intMaxAcc.NewPrivateKeyWithReCalcPubKeyIfPkNegates(privateKey)
 	assert.NoError(t, err)
 
-	message := make([]*ffg.Element, 20)
-	for i := 0; i < len(message); i++ {
-		message[i] = new(ffg.Element).SetUint64(uint64(i))
-	}
-	signature, err := keyPair.Sign(message)
+	messageHex := "99947e33d5d672d82b7f221f4899e31b574314692b3ecd6a01693a7c38af1271"
+	messageBytes, err := hex.DecodeString(messageHex)
+	assert.NoError(t, err)
+	assert.Equal(t, 32, len(messageBytes))
+
+	flattenMessage := finite_field.BytesToFieldElementSlice(messageBytes)
+
+	signature, err := keyPair.Sign(flattenMessage)
 	assert.NoError(t, err)
 
-	err = intMaxAcc.VerifySignature(signature, keyPair.Public(), message)
+	err = intMaxAcc.VerifySignature(signature, keyPair.Public(), flattenMessage)
 	assert.NoError(t, err)
 }
 
 func TestVerifyHexSignature(t *testing.T) {
-	publicKey := new(intMaxAcc.PublicKey)
-	bytes, err := hex.DecodeString("22a0e14b45128c24d8deb2c336de9250ee07357b0b755518e6a8e42058b58a4f10d4f0cea7a7b3996cd919fae2aae91df8171b3bf0cb7c13af68fc1f3038d5f7")
+	addressHex := "0x0ec939a62c909fd83c2af088f24482ae9057f4450a22f6b7d9d3038536356d95"
+	address, err := intMaxAcc.NewAddressFromHex(addressHex)
 	assert.NoError(t, err)
-	err = publicKey.Unmarshal(bytes)
+	publicKey, err := address.Public()
 	assert.NoError(t, err)
-	signature, err := intMaxAcc.DecodeG2CurvePoint("27f811fe50964adcb0345ddf85dd0e2e913229991b1d2a551df2908e8ccd3bfc2ba7d3c0ce4096f524d22afeba96b6ce95a6357b5336f9cc57dc0cc78fa605e604781cec49a668fc7ec5dc22fd5f9e49e2b594b1ff9b8067c97d2b60d6be6cd0048da9489637392dc5c427d7b5e9b0976158a3f06b58820c90245ad68675b8b4")
+
+	signature, err := intMaxAcc.DecodeG2CurvePoint("0367810768faa199d6cb0d4ab3f5ccb0b40ee77197512fb06225b62455e94e0a0c8927695b7e3644306fa82de066df3472784dc7cf9c19ca172141bdf74d4cb9089255ec6a86312ac1d6f6c43c90abc82547f3a47bd8bc6ab68574037c8f271c015c7faefff4762e6d25b17060dd6b8a4ac44a3190fd7096514d4169c98d15e0")
 	assert.NoError(t, err)
 
 	messageHex := "99947e33d5d672d82b7f221f4899e31b574314692b3ecd6a01693a7c38af1271"
@@ -50,13 +52,7 @@ func TestVerifyHexSignature(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 32, len(messageBytes))
 
-	flattenMessage := make([]*ffg.Element, len(messageBytes)/4)
-	for i := 0; i < len(flattenMessage); i++ {
-		// big endian
-		limb := binary.BigEndian.Uint32(messageBytes[4*i : 4*(i+1)])
-		flattenMessage[i] = new(ffg.Element).SetUint64(uint64(limb))
-	}
-
+	flattenMessage := finite_field.BytesToFieldElementSlice(messageBytes)
 	err = intMaxAcc.VerifySignature(signature, publicKey, flattenMessage)
 	assert.NoError(t, err)
 }
@@ -97,12 +93,12 @@ func TestAggregatedSignature(t *testing.T) {
 		aggregatedSignature.Add(aggregatedSignature, signature)
 	}
 
-	aggregatedPublicKey := new(bn254.G1Affine)
+	aggregatedPublicKey := new(intMaxAcc.PublicKey)
 	for _, keyPair := range keyPairs {
 		weightedPublicKey := keyPair.Public().WeightByHash(publicKeysHash)
-		aggregatedPublicKey.Add(aggregatedPublicKey, weightedPublicKey.Pk)
+		aggregatedPublicKey.Add(aggregatedPublicKey, weightedPublicKey)
 	}
 
-	err := intMaxAcc.VerifySignature(aggregatedSignature, intMaxAcc.NewPublicKey(aggregatedPublicKey), flattenTxTreeRoot)
+	err := intMaxAcc.VerifySignature(aggregatedSignature, aggregatedPublicKey, flattenTxTreeRoot)
 	assert.NoError(t, err)
 }

--- a/internal/types/block.go
+++ b/internal/types/block.go
@@ -78,10 +78,10 @@ func NewBlockContent(
 
 	publicKeysHash := crypto.Keccak256(senderPublicKeys)
 
-	aggregatedPublicKey := accounts.NewPublicKey(new(bn254.G1Affine))
+	aggregatedPublicKey := new(accounts.PublicKey)
 	for _, sender := range bc.Senders {
 		if sender.IsSigned {
-			aggregatedPublicKey.Pk.Add(aggregatedPublicKey.Pk, sender.PublicKey.WeightByHash(publicKeysHash).Pk)
+			aggregatedPublicKey.Add(aggregatedPublicKey, sender.PublicKey.WeightByHash(publicKeysHash))
 		}
 	}
 	bc.AggregatedPublicKey = new(accounts.PublicKey).Set(aggregatedPublicKey)
@@ -173,12 +173,12 @@ func (bc *BlockContent) IsValid() error {
 				}
 
 				publicKeysHash := crypto.Keccak256(senderPublicKeys)
-				aggregatedPublicKey := accounts.NewPublicKey(new(bn254.G1Affine))
+				aggregatedPublicKey := new(accounts.PublicKey)
 				for key := range bc.Senders {
 					if bc.Senders[key].IsSigned {
-						aggregatedPublicKey.Pk.Add(
-							aggregatedPublicKey.Pk,
-							bc.Senders[key].PublicKey.WeightByHash(publicKeysHash).Pk,
+						aggregatedPublicKey.Add(
+							aggregatedPublicKey,
+							bc.Senders[key].PublicKey.WeightByHash(publicKeysHash),
 						)
 					}
 				}

--- a/internal/types/block_test.go
+++ b/internal/types/block_test.go
@@ -38,10 +38,8 @@ func TestPublicKeyBlockValidation(t *testing.T) {
 			IsSigned:  true,
 		}
 	}
-	// default is the point which x is 1
-	defaultPublicKey := accounts.NewPublicKey(new(bn254.G1Affine))
-	defaultPublicKey.Pk.X.SetOne()
-	defaultPublicKey.Pk.Y.SetZero() // NOTE: This is not a valid public key
+
+	defaultPublicKey := accounts.NewDummyPublicKey()
 	for i := len(keyPairs); i < len(senders); i++ {
 		senders[i] = intMaxTypes.Sender{
 			PublicKey: defaultPublicKey,
@@ -60,9 +58,9 @@ func TestPublicKeyBlockValidation(t *testing.T) {
 	}
 
 	publicKeysHash := crypto.Keccak256(senderPublicKeys)
-	aggregatedPublicKey := accounts.NewPublicKey(new(bn254.G1Affine))
+	aggregatedPublicKey := new(accounts.PublicKey)
 	for _, sender := range senders {
-		aggregatedPublicKey.Pk.Add(aggregatedPublicKey.Pk, sender.PublicKey.WeightByHash(publicKeysHash).Pk)
+		aggregatedPublicKey.Add(aggregatedPublicKey, sender.PublicKey.WeightByHash(publicKeysHash))
 	}
 
 	message := finite_field.BytesToFieldElementSlice(txRoot.Marshal())
@@ -106,10 +104,8 @@ func TestAccountIDBlockValidation(t *testing.T) {
 			IsSigned:  true,
 		}
 	}
-	// default is the point which x is 1
-	defaultPublicKey := accounts.NewPublicKey(new(bn254.G1Affine))
-	defaultPublicKey.Pk.X.SetOne()
-	defaultPublicKey.Pk.Y.SetZero() // NOTE: This is not a valid public key
+
+	defaultPublicKey := accounts.NewDummyPublicKey()
 	for i := len(keyPairs); i < len(senders); i++ {
 		senders[i] = intMaxTypes.Sender{
 			PublicKey: defaultPublicKey,
@@ -130,10 +126,10 @@ func TestAccountIDBlockValidation(t *testing.T) {
 	}
 
 	publicKeysHash := crypto.Keccak256(senderPublicKeys)
-	aggregatedPublicKey := accounts.NewPublicKey(new(bn254.G1Affine))
+	aggregatedPublicKey := new(accounts.PublicKey)
 	for _, sender := range senders {
 		if sender.IsSigned {
-			aggregatedPublicKey.Pk.Add(aggregatedPublicKey.Pk, sender.PublicKey.WeightByHash(publicKeysHash).Pk)
+			aggregatedPublicKey.Add(aggregatedPublicKey, sender.PublicKey.WeightByHash(publicKeysHash))
 		}
 	}
 


### PR DESCRIPTION
- Add `NewPublicKeyFromAddressHex` function to calculate the public key from the address.
- A validity check is carried out when `NewPublicKey` is executed and an error is returned if incorrect.
- Fix test cases.